### PR TITLE
[#7] remove deepclone retweeted_status

### DIFF
--- a/src/components/status/status.js
+++ b/src/components/status/status.js
@@ -19,7 +19,7 @@ import MentionLink from 'src/components/mention_link/mention_link.vue'
 import generateProfileLink from 'src/services/user_profile_link_generator/user_profile_link_generator'
 import { highlightClass, highlightStyle } from '../../services/user_highlighter/user_highlighter.js'
 import { muteWordHits } from '../../services/status_parser/status_parser.js'
-import { unescape, uniqBy, cloneDeep } from 'lodash'
+import { unescape, uniqBy } from 'lodash'
 import StillImage from '../still-image/still-image.vue'
 
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -217,9 +217,7 @@ const Status = {
     retweeterProfileLink () { return this.generateUserProfileLink(this.statusoid.user.id, this.statusoid.user.screen_name) },
     status () {
       if (this.retweet) {
-        let retweetedStatusClone = cloneDeep(this.statusoid.retweeted_status)
-        retweetedStatusClone.visibility = this.statusoid.visibility
-        return retweetedStatusClone
+        return this.statusoid.retweeted_status
       } else {
         return this.statusoid
       }


### PR DESCRIPTION
close #7 

This should be similar to Mastodon's behavior in terms of the Web UI and API.